### PR TITLE
Add Jenkins installation script

### DIFF
--- a/jenkins-userdata.sh
+++ b/jenkins-userdata.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+sudo apt-get update -y 
+
+curl -fsSL https://pkg.jenkins.io/debian-stable/jenkins.io-2023.key | sudo tee \
+  /usr/share/keyrings/jenkins-keyring.asc > /dev/null
+
+echo deb [signed-by=/usr/share/keyrings/jenkins-keyring.asc] \
+  https://pkg.jenkins.io/debian-stable binary/ | sudo tee \
+  /etc/apt/sources.list.d/jenkins.list > /dev/null
+
+sudo apt-get update -y 
+
+sudo apt install openjdk-17-jre -y 
+
+sudo apt-get install jenkins -y
+
+apt-get update -y
+
+sudo systemctl enable jenkins
+
+sudo systemctl start jenkins
+
+sudo systemctl status jenkins
+
+cat /var/lib/jenkins/secrets/initialAdminPassword


### PR DESCRIPTION
This script installs Jenkins and its dependencies on a Debian-based system, including adding the Jenkins repository and enabling the Jenkins service.