### PR TITLE
Polish docs, add challenges, and sync with current lab portfolio

### DIFF
--- a/LEARNING_PATH.md
+++ b/LEARNING_PATH.md
@@ -110,3 +110,5 @@ These labs are hosted in their own repositories and build on the skills from the
 | 26 | GitOps with ArgoCD | Advanced | [anmutetech/gitops-argocd-lab](https://github.com/anmutetech/gitops-argocd-lab) | Deploy apps via GitOps, auto-sync, self-healing, and rollbacks |
 | 27 | Logging and Observability | Advanced | [anmutetech/logging-observability-lab](https://github.com/anmutetech/logging-observability-lab) | Centralized logging with Promtail, Loki, and Grafana (PLG stack) |
 | 28 | MLOps Pipeline | Advanced | [anmutetech/mlops-pipeline-lab](https://github.com/anmutetech/mlops-pipeline-lab) | Train and serve an ML model with FastAPI, deploy to EKS, monitor with Prometheus |
+| 29 | Healthcare CI/CD | Advanced | [anmutetech/healthcare-cicd-lab](https://github.com/anmutetech/healthcare-cicd-lab) | Build a 3-stage CI/CD pipeline (Test → Build → Deploy) for a healthcare API |
+| 30 | Healthcare DevSecOps | Advanced | [anmutetech/healthcare-devsecops-lab](https://github.com/anmutetech/healthcare-devsecops-lab) | Embed 6 security gates into the pipeline: CodeQL, Trivy, Gitleaks, OPA, Syft, npm audit |

--- a/LEARNING_PATH.md
+++ b/LEARNING_PATH.md
@@ -106,9 +106,10 @@ These labs are hosted in their own repositories and build on the skills from the
 |---|-----|-------|------------|-------------------|
 | 23 | Cloud Migration Infrastructure | Advanced | [anmutetech/cloud-migration-infra](https://github.com/anmutetech/cloud-migration-infra) | Provision EKS with Terraform, deploy Prometheus via Helm, GitHub Actions CI/CD |
 | 24 | Legacy App Modernization | Advanced | [anmutetech/legacy-app-modernization](https://github.com/anmutetech/legacy-app-modernization) | Modernize an e-commerce app with Docker, K8s, CI/CD, and Prometheus |
-| 25 | Container Security Scanning | Advanced | [anmutetech/container-security-lab](https://github.com/anmutetech/container-security-lab) | Scan Docker images with Trivy, gate deployments on vulnerability results |
-| 26 | GitOps with ArgoCD | Advanced | [anmutetech/gitops-argocd-lab](https://github.com/anmutetech/gitops-argocd-lab) | Deploy apps via GitOps, auto-sync, self-healing, and rollbacks |
-| 27 | Logging and Observability | Advanced | [anmutetech/logging-observability-lab](https://github.com/anmutetech/logging-observability-lab) | Centralized logging with Promtail, Loki, and Grafana (PLG stack) |
-| 28 | MLOps Pipeline | Advanced | [anmutetech/mlops-pipeline-lab](https://github.com/anmutetech/mlops-pipeline-lab) | Train and serve an ML model with FastAPI, deploy to EKS, monitor with Prometheus |
-| 29 | Healthcare CI/CD | Advanced | [anmutetech/healthcare-cicd-lab](https://github.com/anmutetech/healthcare-cicd-lab) | Build a 3-stage CI/CD pipeline (Test → Build → Deploy) for a healthcare API |
-| 30 | Healthcare DevSecOps | Advanced | [anmutetech/healthcare-devsecops-lab](https://github.com/anmutetech/healthcare-devsecops-lab) | Embed 6 security gates into the pipeline: CodeQL, Trivy, Gitleaks, OPA, Syft, npm audit |
+| 25 | NovaMart Cloud Migration | Advanced | [anmutetech/novamart-cloud-migration-lab](https://github.com/anmutetech/novamart-cloud-migration-lab) | 3-phase cloud migration (Rehost → Re-platform → Re-architect) with Terraform and EKS |
+| 26 | Container Security Scanning | Advanced | [anmutetech/container-security-lab](https://github.com/anmutetech/container-security-lab) | VaultPay fintech — Trivy scanning, PCI-DSS compliance gates |
+| 27 | GitOps with ArgoCD | Advanced | [anmutetech/gitops-argocd-lab](https://github.com/anmutetech/gitops-argocd-lab) | Deploy apps via GitOps, auto-sync, self-healing, and rollbacks |
+| 28 | Logging and Observability | Advanced | [anmutetech/logging-observability-lab](https://github.com/anmutetech/logging-observability-lab) | ShopStream e-commerce — centralized logging with PLG stack |
+| 29 | MLOps Pipeline | Advanced | [anmutetech/mlops-pipeline-lab](https://github.com/anmutetech/mlops-pipeline-lab) | RiskGuard Insurance — ML risk predictor with FastAPI, EKS, Prometheus |
+| 30 | Healthcare CI/CD | Advanced | [anmutetech/healthcare-cicd-lab](https://github.com/anmutetech/healthcare-cicd-lab) | Build a 3-stage CI/CD pipeline (Test → Build → Deploy) for a healthcare API |
+| 31 | Healthcare DevSecOps | Advanced | [anmutetech/healthcare-devsecops-lab](https://github.com/anmutetech/healthcare-devsecops-lab) | 7-stage DevSecOps pipeline with SonarCloud, Trivy, Gitleaks, and OPA/Conftest |

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -55,7 +55,10 @@ Fork this repository and check off modules as you complete them.
 ## Advanced Labs (Standalone Repositories)
 - [ ] Cloud Migration Infrastructure
 - [ ] Legacy App Modernization
-- [ ] Container Security Scanning
+- [ ] NovaMart Cloud Migration
+- [ ] Container Security Scanning (VaultPay)
 - [ ] GitOps with ArgoCD
-- [ ] Logging and Observability
-- [ ] MLOps Pipeline
+- [ ] Logging and Observability (ShopStream)
+- [ ] MLOps Pipeline (RiskGuard)
+- [ ] Healthcare CI/CD
+- [ ] Healthcare DevSecOps

--- a/README.md
+++ b/README.md
@@ -78,13 +78,14 @@ These labs build on the skills from the modules above and are hosted in their ow
 |-----|------------|-------------|
 | Cloud Migration Infrastructure | [anmutetech/cloud-migration-infra](https://github.com/anmutetech/cloud-migration-infra) | Provision EKS with Terraform, deploy Prometheus via Helm, GitHub Actions CI/CD |
 | Legacy App Modernization | [anmutetech/legacy-app-modernization](https://github.com/anmutetech/legacy-app-modernization) | Modernize an e-commerce app with Docker, K8s, CI/CD, and Prometheus |
-| Container Security Scanning | [anmutetech/container-security-lab](https://github.com/anmutetech/container-security-lab) | Scan Docker images with Trivy, gate deployments on vulnerability results |
+| NovaMart Cloud Migration | [anmutetech/novamart-cloud-migration-lab](https://github.com/anmutetech/novamart-cloud-migration-lab) | 3-phase cloud migration (Rehost → Re-platform → Re-architect) with Terraform and EKS |
+| Container Security Scanning | [anmutetech/container-security-lab](https://github.com/anmutetech/container-security-lab) | VaultPay fintech payment gateway — Trivy scanning, PCI-DSS compliance gates |
 | GitOps with ArgoCD | [anmutetech/gitops-argocd-lab](https://github.com/anmutetech/gitops-argocd-lab) | Deploy apps via GitOps, auto-sync, self-healing, and rollbacks |
-| Logging and Observability | [anmutetech/logging-observability-lab](https://github.com/anmutetech/logging-observability-lab) | Centralized logging with Promtail, Loki, and Grafana (PLG stack) |
-| MLOps Pipeline | [anmutetech/mlops-pipeline-lab](https://github.com/anmutetech/mlops-pipeline-lab) | Train and serve an ML model with FastAPI, deploy to EKS, monitor with Prometheus |
+| Logging and Observability | [anmutetech/logging-observability-lab](https://github.com/anmutetech/logging-observability-lab) | ShopStream e-commerce — centralized logging with Promtail, Loki, and Grafana (PLG stack) |
+| MLOps Pipeline | [anmutetech/mlops-pipeline-lab](https://github.com/anmutetech/mlops-pipeline-lab) | RiskGuard Insurance — ML risk predictor with FastAPI, deploy to EKS, Prometheus metrics |
 | Healthcare CI/CD | [anmutetech/healthcare-cicd-lab](https://github.com/anmutetech/healthcare-cicd-lab) | Build a CI/CD pipeline for a healthcare patient appointment API with GitHub Actions |
-| Healthcare DevSecOps | [anmutetech/healthcare-devsecops-lab](https://github.com/anmutetech/healthcare-devsecops-lab) | Embed 6 security gates (CodeQL, Trivy, Gitleaks, OPA, Syft, npm audit) into a CI/CD pipeline |
+| Healthcare DevSecOps | [anmutetech/healthcare-devsecops-lab](https://github.com/anmutetech/healthcare-devsecops-lab) | 7-stage DevSecOps pipeline with SonarCloud, Trivy, Gitleaks, and OPA/Conftest |
 
 ## Technologies Covered
 
-AWS (EC2, EKS, IAM, Lambda, Secrets Manager, S3) · Docker · Docker Compose · Kubernetes · Helm · Terraform · Ansible · Jenkins · Azure Pipelines · GitHub Actions · Prometheus · Grafana · Loki · Fluent Bit · ArgoCD · Trivy · CodeQL · Gitleaks · OPA/Conftest · Syft · SonarQube · FastAPI · Spring Boot · Flask · Node.js · Nginx · Bash
+AWS (EC2, EKS, IAM, Lambda, Secrets Manager, S3) · Docker · Docker Compose · Kubernetes · Helm · Terraform · Ansible · Jenkins · Azure Pipelines · GitHub Actions · Prometheus · Grafana · Loki · Fluent Bit · ArgoCD · Trivy · SonarCloud · Gitleaks · OPA/Conftest · SonarQube · FastAPI · Spring Boot · Flask · Node.js · Nginx · Bash

--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ These labs build on the skills from the modules above and are hosted in their ow
 | GitOps with ArgoCD | [anmutetech/gitops-argocd-lab](https://github.com/anmutetech/gitops-argocd-lab) | Deploy apps via GitOps, auto-sync, self-healing, and rollbacks |
 | Logging and Observability | [anmutetech/logging-observability-lab](https://github.com/anmutetech/logging-observability-lab) | Centralized logging with Promtail, Loki, and Grafana (PLG stack) |
 | MLOps Pipeline | [anmutetech/mlops-pipeline-lab](https://github.com/anmutetech/mlops-pipeline-lab) | Train and serve an ML model with FastAPI, deploy to EKS, monitor with Prometheus |
+| Healthcare CI/CD | [anmutetech/healthcare-cicd-lab](https://github.com/anmutetech/healthcare-cicd-lab) | Build a CI/CD pipeline for a healthcare patient appointment API with GitHub Actions |
+| Healthcare DevSecOps | [anmutetech/healthcare-devsecops-lab](https://github.com/anmutetech/healthcare-devsecops-lab) | Embed 6 security gates (CodeQL, Trivy, Gitleaks, OPA, Syft, npm audit) into a CI/CD pipeline |
 
 ## Technologies Covered
 
-AWS (EC2, EKS, IAM, Lambda, Secrets Manager, S3) · Docker · Docker Compose · Kubernetes · Helm · Terraform · Ansible · Jenkins · Azure Pipelines · GitHub Actions · Prometheus · Grafana · Loki · Fluent Bit · ArgoCD · Trivy · SonarQube · FastAPI · Spring Boot · Flask · Node.js · Nginx · Bash
+AWS (EC2, EKS, IAM, Lambda, Secrets Manager, S3) · Docker · Docker Compose · Kubernetes · Helm · Terraform · Ansible · Jenkins · Azure Pipelines · GitHub Actions · Prometheus · Grafana · Loki · Fluent Bit · ArgoCD · Trivy · CodeQL · Gitleaks · OPA/Conftest · Syft · SonarQube · FastAPI · Spring Boot · Flask · Node.js · Nginx · Bash


### PR DESCRIPTION
## Summary
- Add challenge exercises for all 8 training phases
- Add prerequisites guide with macOS and Windows installation instructions
- Add progress tracker, contributing guide, and .gitignore
- Upgrade architecture diagrams to detailed box-drawing style
- Add Healthcare CI/CD and DevSecOps labs to learning path
- Update lab descriptions to reflect current scenarios (VaultPay, ShopStream, RiskGuard, NovaMart)
- Replace outdated tool references (CodeQL/Syft → SonarCloud) in DevSecOps description
- Remove tracked .DS_Store files

## Test plan
- [ ] Verify all repo links in README and LEARNING_PATH resolve correctly
- [ ] Confirm lab descriptions match current state of each standalone repo
- [ ] Check progress tracker includes all labs